### PR TITLE
Check if lfs files have valid pointers

### DIFF
--- a/.github/workflows/misc-test.yml
+++ b/.github/workflows/misc-test.yml
@@ -15,8 +15,8 @@ jobs:
         lfs: false
     - name: Install apt packages
       run: |
-        apt-get update
-        apt-get install -y --no-install-recommends git git-lfs
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends git git-lfs
       env:
         DEBIAN_FRONTEND: noninteractive
     - name: Run lfs-pointer-check


### PR DESCRIPTION
今回のリポジトリ移行で、大きいファイルはGit LFSで管理するようにしました。（git indexを極力コンパクトに保つことが目的です）
git の使い方は特に変わりませんが、リポジトリ関係なくマシン上で一回以上は `git lfs install` を実行する必要があります。（`git lfs install` をすると `~/.gitconfig` に filter がインストールされます。これが各リポジトリの `checkout` などのタイミングで呼ばれる感じです）

一方でlfsを使うことの問題点として、lfsが適切に設定されていない環境で大きいファイルを git commit をしてしまうと、LFSにトラックされずに直接 git index へファイルをトラックできてしまう上、特にエラーなく commit && push ができてしまうということが挙げられます。
このPRでは、それを正しく検出するためのツール https://github.com/bonprosoft/lfs-pointer-check をCI上で走らせるように設定しました。

同時に、一定以上のサイズのファイルがlfsにトラックされていないようであればエラーを出すようにも設定しました。
現状だと1MB以上のファイルについては原則 git lfs へとトラックされるべきと考えてCIを設定しています。