### PR TITLE
Use kwonly arguments in set_allout

### DIFF
--- a/samples/akari_sample/script/3a_gpio_control.py
+++ b/samples/akari_sample/script/3a_gpio_control.py
@@ -87,7 +87,7 @@ def main() -> None:
         print("STEP5. Reset all output")
         # reset_alloutを実行
         m5.reset_allout()
-        print(f"-> Reset")
+        print("-> Reset")
         # 2秒停止
         time.sleep(2)
         print()
@@ -119,7 +119,7 @@ def main() -> None:
         # pwmout0_valでpwmout0の出力値を設定
         pwmout0_val = 200
         # set_alloutを実行
-        m5.set_allout(dout0_val, dout1_val, pwmout0_val)
+        m5.set_allout(dout0=dout0_val, dout1=dout1_val, pwmout0=pwmout0_val)
         print("-> Set")
         # 2秒停止
         time.sleep(2)

--- a/sdk/akari_controller/src/akari_controller/m5serial_server_py.py
+++ b/sdk/akari_controller/src/akari_controller/m5serial_server_py.py
@@ -97,11 +97,16 @@ class M5SerialServer:
         self._write_pin_out(sync=sync)
 
     def set_allout(
-        self, dout0_val: bool, dout1_val: bool, pwmout0_val: int, sync: bool = True
+        self,
+        *,
+        dout0: bool,
+        dout1: bool,
+        pwmout0: int,
+        sync: bool = True,
     ) -> None:
-        self._pin_out.dout0 = dout0_val
-        self._pin_out.dout1 = dout1_val
-        self._pin_out.pwmout0 = pwmout0_val
+        self._pin_out.dout0 = dout0
+        self._pin_out.dout1 = dout1
+        self._pin_out.pwmout0 = pwmout0
 
         self._write_pin_out(sync=sync)
 


### PR DESCRIPTION
Merge #8 first

`set_allout` で positional arguments を使うと仕様変更に脆くなるので、この関数では keyword only arguments にしたいです。

@kazyam53 @takuya-ikeda-tri 