### PR TITLE
Move controller initialization logic

### DIFF
--- a/sdk/akari_client/akari_client/akari_client.py
+++ b/sdk/akari_client/akari_client/akari_client.py
@@ -5,15 +5,29 @@ from typing import Any
 
 from .joint_manager import JointManager
 from .m5stack_client import M5StackClient
+from .serial.dynamixel import create_controllers
+from .serial.dynamixel_communicator import DynamixelCommunicator
 from .serial.m5stack import M5StackSerialClient
+
+
+def _initialize_joint_manager(
+    stack: contextlib.ExitStack,
+) -> JointManager:
+    communicator = stack.enter_context(DynamixelCommunicator.open())
+    controllers = create_controllers(communicator)
+    return JointManager(controllers)
+
+
+def _initialize_m5stack(stack: contextlib.ExitStack) -> M5StackClient:
+    return stack.enter_context(M5StackSerialClient())
 
 
 class AkariClient:
     def __init__(self) -> None:
         self._stack = contextlib.ExitStack()
 
-        self._joints = self._stack.enter_context(JointManager())
-        self._m5stack = self._stack.enter_context(M5StackSerialClient())
+        self._joints = _initialize_joint_manager(self._stack)
+        self._m5stack = _initialize_m5stack(self._stack)
 
     def __enter__(self) -> AkariClient:
         return self

--- a/sdk/akari_client/akari_client/serial/dynamixel.py
+++ b/sdk/akari_client/akari_client/serial/dynamixel.py
@@ -1,7 +1,9 @@
 import dataclasses
 import math
+from typing import List
 
 from ..joint_controller import JointControllerConfig, RevoluteJointController
+from ..joint_manager import AkariJoint
 from .dynamixel_communicator import DynamixelCommunicator
 
 PULSE_OFFSET = 2047
@@ -152,3 +154,32 @@ class DynamixelController(RevoluteJointController):
         return dynamixel_pulse_to_rad(
             self._read(DynamixelControlTable.PRESENT_POSITION)
         )
+
+
+_DEFAULT_JOINT_CONFIGS: List[DynamixelControllerConfig] = [
+    DynamixelControllerConfig(
+        joint_name=AkariJoint.PAN,
+        dynamixel_id=1,
+    ),
+    DynamixelControllerConfig(
+        joint_name=AkariJoint.TILT,
+        dynamixel_id=2,
+    ),
+]
+
+
+def create_controllers(
+    communicator: DynamixelCommunicator,
+) -> List[DynamixelController]:
+    joints: List[DynamixelController] = []
+    for config in _DEFAULT_JOINT_CONFIGS:
+        # TODO: Dispatch ControllerInitialization by a config class
+        assert isinstance(config, DynamixelControllerConfig)
+        joints.append(
+            DynamixelController(
+                config,
+                communicator,
+            )
+        )
+
+    return joints


### PR DESCRIPTION
gRPCサーバーを使うか、Serialを使うかのスイッチングを AkariClient 内部で行うことを見据えて、各クラスの初期化場所を一旦変更しました。
（この後に Config クラスを読んで実際に初期化する処理を入れることになると思いますが、ゴチャゴチャになる前に一旦分けました。）

@kazyam53 @takuya-ikeda-tri 