### PR TITLE
Update build context for daemon/gateway

### DIFF
--- a/internal/akira_services/docker-compose.image.yml
+++ b/internal/akira_services/docker-compose.image.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../
       dockerfile: internal/akira_services/jupyter_lab/Dockerfile
-    image: akarirobot/akira-jupyter-service:v1
+    image: akarirobot/akira-service-jupyter:v1
     command: exit 1
   akari_rpc_server:
     build:

--- a/internal/docker/Dockerfile
+++ b/internal/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.18.2-alpine3.16 AS build
 
 WORKDIR /src
-COPY akira .
+COPY internal/akira .
 
 ARG GOOS linux
 ARG GOARCH amd64
@@ -21,9 +21,9 @@ RUN apk add --no-cache shadow
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing gosu
 
 WORKDIR /app
-COPY docker/daemon-entrypoint.sh /entrypoint.sh
+COPY internal/docker/daemon-entrypoint.sh /entrypoint.sh
 COPY --from=build /build/daemon .
-COPY akira_templates /templates
+COPY internal/akira_templates /templates
 
 RUN mkdir -p /projects /etc/akira /var/lib/akira
 

--- a/internal/docker/docker-compose.dev.yml
+++ b/internal/docker/docker-compose.dev.yml
@@ -2,9 +2,10 @@ version: "3.7"
 services:
   daemon:
     build:
-      context: ../
-      dockerfile: docker/Dockerfile
+      context: ../../
+      dockerfile: internal/docker/Dockerfile
       target: daemon
+    image: akarirobot/akira-daemon:v1
     volumes:
       - type: bind
         source: ${AKARI_REPOSITORY_DIR:?You need to run `source env.sh`}/internal/akira_templates
@@ -28,7 +29,8 @@ services:
     network_mode: host
   gateway:
     build:
-      context: ../
-      dockerfile: docker/Dockerfile
+      context: ../../
+      dockerfile: internal/docker/Dockerfile
       target: gateway
+    image: akarirobot/akira-gateway:v1
     network_mode: host


### PR DESCRIPTION
`internal/docker` のビルドコンテキストとして repository root を使うようにしました。
またついでに `akira-jupyter-service` → `akira-service-jupyter` のrenameも行ってしまいました :bowing_man: 

@kazyam53 @takuya-ikeda-tri 