### PR TITLE
Use container scoped network for akira daemon

### DIFF
--- a/internal/docker/docker-compose.dev.yml
+++ b/internal/docker/docker-compose.dev.yml
@@ -26,11 +26,13 @@ services:
       AKIRA_VAR_DIR: ${AKIRA_DEV_LOCAL_DIR}/var/lib/akira
       # Required until the project gets open-sourced
       AKIRA_DOCKER_CREDENTIAL: ${AKIRA_DOCKER_CREDENTIAL:?You need to run `source env.sh`}
-    network_mode: host
   gateway:
     build:
       context: ../../
       dockerfile: internal/docker/Dockerfile
       target: gateway
     image: akarirobot/akira-gateway:${AKIRA_IMAGE_TAG}
-    network_mode: host
+    environment:
+      AKIRA_DAEMON_ENDPOINT: daemon:30001
+    ports:
+      - 8080:8080

--- a/internal/docker/docker-compose.v1.yml
+++ b/internal/docker/docker-compose.v1.yml
@@ -25,7 +25,9 @@ services:
       AKIRA_VAR_DIR: /var/lib/akira
       # Required until the project gets open-sourced
       AKIRA_DOCKER_CREDENTIAL: ${AKIRA_DOCKER_CREDENTIAL:?You need to run `source env.sh`}
-    network_mode: host
   gateway:
     image: akarirobot/akira-gateway:${AKIRA_IMAGE_TAG}
-    network_mode: host
+    environment:
+      AKIRA_DAEMON_ENDPOINT: daemon:30001
+    ports:
+      - 8080:8080


### PR DESCRIPTION
akira daemon を起動する時に `network_mode: host` で起動するのをやめました。

`/var/run/docker.sock` をマウントしているような daemon の gRPC ポートをネットワークへ露出させるのは（主にセキュリティ的な観点から）ちょっとあまりよろしくなく、gRPC gateway 経由でアクセスするようにしたい感じです。

@kazyam53 @takuya-ikeda-tri 