### PR TITLE
Refactor service interface

### DIFF
--- a/internal/akira/daemon/service.go
+++ b/internal/akira/daemon/service.go
@@ -53,8 +53,10 @@ func imageToPb(c service.ImageConfig) *proto.ServiceImage {
 }
 
 func serviceToPb(m service.ServiceManager, s service.Service) *proto.Service {
+	config := s.Config()
+
 	var image *proto.ServiceImage = nil
-	if imgId := s.ImageId(); imgId != service.NullImageId {
+	if imgId := config.ImageId; imgId != service.NullImageId {
 		if c, ok := m.GetImage(imgId); ok {
 			image = imageToPb(c)
 		} else {
@@ -65,8 +67,8 @@ func serviceToPb(m service.ServiceManager, s service.Service) *proto.Service {
 	return &proto.Service{
 		Id:           string(s.Id()),
 		Image:        image,
-		DisplayName:  s.DisplayName(),
-		Description:  s.Description(),
+		DisplayName:  config.DisplayName,
+		Description:  config.Description,
 		Status:       serviceStatusToPb(s.Status()),
 		Type:         serviceTypeToPb(s.Type()),
 		Capabilities: capabilitiesToPb(s.Capabilities()),

--- a/internal/akira/service/factory.go
+++ b/internal/akira/service/factory.go
@@ -26,10 +26,10 @@ func grpcClientConfigMount(etcDir string) mount.Mount {
 	}
 }
 
-func akariRpcServerSystemServiceConfig(etcDir string) (SystemServiceConfig, error) {
+func akariRpcServerSystemServiceConfig(etcDir string) (ServiceConfig, system.CreateContainerOption, error) {
 	etcPath := filepath.Join(etcDir, AkariClientConfigHostRpcServer)
 	if _, err := os.Stat(etcPath); err != nil {
-		return SystemServiceConfig{}, fmt.Errorf("file error: %#v", err)
+		return ServiceConfig{}, system.CreateContainerOption{}, fmt.Errorf("file error: %#v", err)
 	}
 
 	id := ServiceId("daa0fee2-2390-43ad-bed8-88d7365311b1")
@@ -47,21 +47,25 @@ func akariRpcServerSystemServiceConfig(etcDir string) (SystemServiceConfig, erro
 		},
 	}
 	containerPort := fmt.Sprintf("%d/tcp", AkariRpcServerServicePort)
-	return SystemServiceConfig{
+	serviceConfig := ServiceConfig{
 		Id:          id,
+		ImageId:     NullImageId,
 		DisplayName: "AkariRpcServer",
 		Description: "gRPC server for host devices",
-		ContainerOption: system.CreateContainerOption{
-			Image: "akarirobot/akari-rpc-server:v1",
-			Env:   []string{},
-			Ports: map[string]int{
-				containerPort: AkariRpcServerServicePort,
-			},
-			Mounts:      mountsConfig,
-			RequireRoot: true,
-			Privileged:  true,
+		AutoStart:   true,
+	}
+	containerOpts := system.CreateContainerOption{
+		Image: "akarirobot/akari-rpc-server:v1",
+		Env:   []string{},
+		Ports: map[string]int{
+			containerPort: AkariRpcServerServicePort,
 		},
-	}, nil
+		Mounts:      mountsConfig,
+		RequireRoot: true,
+		Privileged:  true,
+	}
+
+	return serviceConfig, containerOpts, nil
 }
 
 func jupyterLabImageConfig() ImageConfig {

--- a/internal/akira/service/service.go
+++ b/internal/akira/service/service.go
@@ -2,13 +2,8 @@ package service
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"sync"
 
-	"github.com/go-playground/validator/v10"
-	yaml "github.com/goccy/go-yaml"
 	"github.com/google/uuid"
 )
 
@@ -40,15 +35,6 @@ func NewServiceId() ServiceId {
 	return ServiceId(uuid.New().String())
 }
 
-type ServiceConfig struct {
-	Id      ServiceId `json:"id" validate:"required"`
-	ImageId ImageId   `json:"image_id" validate:"required"`
-
-	DisplayName string `json:"display_name" validate:"required"`
-	Description string `json:"description"`
-	AutoStart   bool   `json:"auto_start"`
-}
-
 type serviceTask struct {
 	err error
 	wg  sync.WaitGroup
@@ -76,12 +62,9 @@ type ServiceTask interface {
 
 type Service interface {
 	Id() ServiceId
-	DisplayName() string
-	Description() string
-	ImageId() ImageId
+	Config() ServiceConfig
 	Type() ServiceType
 	Capabilities() []ServiceCapability
-	AutoStart() bool
 
 	Start(context.Context) (ServiceTask, error)
 	Stop(context.Context) (ServiceTask, error)
@@ -91,42 +74,4 @@ type Service interface {
 
 	GetOpenAddress(hostName string) (string, error)
 	GetOpenProjectAddress(hostName string, projectDir string) (string, error)
-}
-
-func loadServiceConfig(p string) (ServiceConfig, error) {
-	content, err := ioutil.ReadFile(p)
-	if err != nil {
-		return ServiceConfig{}, err
-	}
-
-	v := validator.New()
-	var config ServiceConfig
-	err = yaml.UnmarshalWithOptions(
-		content,
-		&config,
-		yaml.Strict(),
-		yaml.Validator(v),
-	)
-	return config, err
-}
-
-func saveServiceConfig(c ServiceConfig, p string) error {
-	content, err := yaml.Marshal(c)
-	if err != nil {
-		return err
-	}
-
-	dir := filepath.Dir(p)
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return err
-	}
-
-	fs, err := os.Create(p)
-	if err != nil {
-		return err
-	}
-
-	fs.Write(content)
-	fs.Close()
-	return nil
 }

--- a/internal/akira/service/service_config.go
+++ b/internal/akira/service/service_config.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/go-playground/validator/v10"
+	yaml "github.com/goccy/go-yaml"
+)
+
+type ServiceConfig struct {
+	Id          ServiceId `json:"id" validate:"required"`
+	ImageId     ImageId   `json:"image_id" validate:"required"`
+	DisplayName string    `json:"display_name" validate:"required"`
+	Description string    `json:"description"`
+	AutoStart   bool      `json:"auto_start"`
+}
+
+type ServiceConfigAccessor struct {
+	config ServiceConfig
+}
+
+func (g *ServiceConfigAccessor) Id() ServiceId {
+	return g.config.Id
+}
+
+func (g *ServiceConfigAccessor) Config() ServiceConfig {
+	return g.config
+}
+
+type ServiceConfigLoader struct {
+	config     *ServiceConfig
+	configPath string
+}
+
+func (w *ServiceConfigLoader) LoadConfig() error {
+	content, err := ioutil.ReadFile(w.configPath)
+	if err != nil {
+		return err
+	}
+
+	v := validator.New()
+	if err = yaml.UnmarshalWithOptions(
+		content,
+		w.config,
+		yaml.Strict(),
+		yaml.Validator(v),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *ServiceConfigLoader) SaveConfig() error {
+	content, err := yaml.Marshal(w.config)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(w.configPath)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
+
+	fs, err := os.Create(w.configPath)
+	if err != nil {
+		return err
+	}
+
+	fs.Write(content)
+	fs.Close()
+	return nil
+}

--- a/internal/akira/service/system_service.go
+++ b/internal/akira/service/system_service.go
@@ -1,48 +1,28 @@
 package service
 
 import (
-	"context"
 	"errors"
 
 	"github.com/AkariGroup/akari_software/internal/akira/system"
 )
 
-type SystemServiceConfig struct {
-	Id              ServiceId                    `json:"id" validate:"required"`
-	DisplayName     string                       `json:"display_name" validate:"required"`
-	Description     string                       `json:"description"`
-	ContainerOption system.CreateContainerOption `json:"container_option" validate:"required"`
-}
-
 type SystemService struct {
-	config    SystemServiceConfig
-	opts      ServiceManagerOptions
-	container *ServiceContainer
+	opts          ServiceManagerOptions
+	containerOpts system.CreateContainerOption
+
+	*ServiceContainer
+	*ServiceConfigAccessor
 }
 
-func NewSystemService(config SystemServiceConfig, opts ServiceManagerOptions) *SystemService {
+func NewSystemService(config ServiceConfig, containerOpts system.CreateContainerOption, opts ServiceManagerOptions) *SystemService {
 	p := &SystemService{
-		config: config,
-		opts:   opts,
+		opts:          opts,
+		containerOpts: containerOpts,
+
+		ServiceConfigAccessor: &ServiceConfigAccessor{config},
 	}
-	p.container = NewServiceContainer(p, opts.Docker)
+	p.ServiceContainer = NewServiceContainer(p, opts.Docker)
 	return p
-}
-
-func (p *SystemService) Id() ServiceId {
-	return p.config.Id
-}
-
-func (p *SystemService) DisplayName() string {
-	return p.config.DisplayName
-}
-
-func (p *SystemService) Description() string {
-	return p.config.Description
-}
-
-func (p *SystemService) ImageId() ImageId {
-	return NullImageId
 }
 
 func (p *SystemService) Type() ServiceType {
@@ -53,32 +33,12 @@ func (p *SystemService) Capabilities() []ServiceCapability {
 	return nil
 }
 
-func (p *SystemService) AutoStart() bool {
-	return true
-}
-
 func (p *SystemService) createContainerConfig() (system.CreateContainerOption, interface{}, error) {
-	return p.config.ContainerOption, nil, nil
-}
-
-func (p *SystemService) Start(ctx context.Context) (ServiceTask, error) {
-	return p.container.Start(ctx)
-}
-
-func (p *SystemService) Stop(ctx context.Context) (ServiceTask, error) {
-	return p.container.Stop(ctx)
-}
-
-func (p *SystemService) Terminate(ctx context.Context) (ServiceTask, error) {
-	return p.container.Terminate(ctx)
+	return p.containerOpts, nil, nil
 }
 
 func (p *SystemService) Clean() error {
 	return nil
-}
-
-func (p *SystemService) Status() ServiceStatus {
-	return p.container.Status()
 }
 
 func (p *SystemService) GetOpenAddress(hostName string) (string, error) {

--- a/internal/akira/service/user_service.go
+++ b/internal/akira/service/user_service.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+type UserServiceProvider struct {
+	image ImageConfig
+	opts  ServiceManagerOptions
+
+	*ServiceContainer
+	*ServiceConfigAccessor
+	*ServiceConfigLoader
+}
+
+func NewUserServiceProvider(
+	fa containerConfigFactory,
+	config ServiceConfig,
+	configPath string,
+	image ImageConfig,
+	opts ServiceManagerOptions,
+) *UserServiceProvider {
+	p := &UserServiceProvider{
+		image: image,
+		opts:  opts,
+
+		ServiceContainer: NewServiceContainer(fa, opts.Docker),
+	}
+	p.ServiceConfigAccessor = &ServiceConfigAccessor{config: config}
+	p.ServiceConfigLoader = &ServiceConfigLoader{&p.ServiceConfigAccessor.config, configPath}
+	return p
+}
+
+func (p *UserServiceProvider) varDir() string {
+	return filepath.Join(p.opts.ServiceVarDir, string(p.ServiceConfigAccessor.Id()))
+}
+
+func (p *UserServiceProvider) Type() ServiceType {
+	return ServiceTypeUser
+}
+
+func (p *UserServiceProvider) Capabilities() []ServiceCapability {
+	return p.image.Capabilities
+}
+
+func (p *UserServiceProvider) Clean() error {
+	ret := p.ServiceContainer.onCriticalSection(func() interface{} {
+		if p.ServiceContainer.Status() != Terminated {
+			return errors.New("cannot remove directory of existing container")
+		}
+
+		return os.RemoveAll(p.varDir())
+	})
+	if err, ok := ret.(error); ok {
+		return err
+	}
+	return nil
+}
+
+func (p *UserServiceProvider) SetConfig(c ServiceConfig) error {
+	p.ServiceConfigAccessor.config = c
+	return nil
+}


### PR DESCRIPTION
PRが大きくなって申し訳ないのですが、Service まわりのクラスをリファクタリングしました :bowing_man: 

- embeddingを使って共通の処理をまとめるようにしました
- ServiceConfig 構造体 を UserService と SystemService の両方で使うようにすることで、Service interfaceをシンプルにしました
- serviceManeger に実装されていた config の保存・ロード処理を、`ServiceConfigLoader` 構造体以下にまとめました。
