### PR TITLE
Manage auto_start property in yaml file

### DIFF
--- a/internal/akira/daemon/daemon.go
+++ b/internal/akira/daemon/daemon.go
@@ -79,6 +79,10 @@ func NewDaemon(config NewDaemonConfig) (*Daemon, error) {
 	if err != nil {
 		return nil, err
 	}
+	serviceManagerConfigDir, err := setupDir(varDir, "configs/service_manager")
+	if err != nil {
+		return nil, err
+	}
 	serviceVarDir, err := setupDir(varDir, "services")
 	if err != nil {
 		return nil, err
@@ -108,12 +112,13 @@ func NewDaemon(config NewDaemonConfig) (*Daemon, error) {
 	tm := project.NewTemplateManager(templateDir)
 	tm.UpdateTemplates()
 	opts := service.ServiceManagerOptions{
-		ImageConfigDir:   imageConfigDir,
-		ServiceConfigDir: serviceConfigDir,
-		ServiceVarDir:    serviceVarDir,
-		EtcDir:           etcDir,
-		ProjectRootDir:   projectDir,
-		Docker:           docker,
+		ImageConfigDir:          imageConfigDir,
+		ServiceConfigDir:        serviceConfigDir,
+		ServiceManagerConfigDir: serviceManagerConfigDir,
+		ServiceVarDir:           serviceVarDir,
+		EtcDir:                  etcDir,
+		ProjectRootDir:          projectDir,
+		Docker:                  docker,
 	}
 	svr, err := service.NewServiceManager(opts)
 	if err != nil {

--- a/internal/akira/service/factory.go
+++ b/internal/akira/service/factory.go
@@ -52,7 +52,6 @@ func akariRpcServerSystemServiceConfig(etcDir string) (ServiceConfig, system.Cre
 		ImageId:     NullImageId,
 		DisplayName: "AkariRpcServer",
 		Description: "gRPC server for host devices",
-		AutoStart:   true,
 	}
 	containerOpts := system.CreateContainerOption{
 		Image: "akarirobot/akari-rpc-server:v1",

--- a/internal/akira/service/service_autostart.go
+++ b/internal/akira/service/service_autostart.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/go-playground/validator/v10"
+	yaml "github.com/goccy/go-yaml"
+)
+
+type ServiceAutoStartConfig struct {
+	Services map[ServiceId]bool `json:"services" validate:"required"`
+}
+
+type ServiceAutoStartManager struct {
+	config     ServiceAutoStartConfig
+	configPath string
+
+	mu sync.Mutex
+}
+
+func NewServiceAutoStartManager(configPath string) *ServiceAutoStartManager {
+	return &ServiceAutoStartManager{
+		config: ServiceAutoStartConfig{
+			Services: make(map[ServiceId]bool),
+		},
+		configPath: configPath,
+	}
+}
+
+func (m *ServiceAutoStartManager) LoadConfig() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	content, err := os.ReadFile(m.configPath)
+	if err != nil {
+		// NOTE: Do nothing if config file is missing
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	v := validator.New()
+	if err = yaml.UnmarshalWithOptions(
+		content,
+		&m.config,
+		yaml.Strict(),
+		yaml.Validator(v),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ServiceAutoStartManager) SaveConfig() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	content, err := yaml.Marshal(m.config)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(m.configPath)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
+
+	fs, err := os.Create(m.configPath)
+	if err != nil {
+		return err
+	}
+
+	fs.Write(content)
+	fs.Close()
+	return nil
+}
+
+func (m *ServiceAutoStartManager) Cleanup(services map[ServiceId]interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for s, _ := range m.config.Services {
+		_, ok := services[s]
+		if !ok {
+			delete(m.config.Services, s)
+		}
+	}
+}
+
+func (m *ServiceAutoStartManager) GetEnabled(id ServiceId) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// NOTE: config.Services might contains false values if the config file is edited manually
+	v, autoStart := m.config.Services[id]
+	return v && autoStart
+}
+
+func (m *ServiceAutoStartManager) SetEnabled(id ServiceId, enabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if enabled {
+		m.config.Services[id] = true
+	} else {
+		delete(m.config.Services, id)
+	}
+}

--- a/internal/akira/service/service_config.go
+++ b/internal/akira/service/service_config.go
@@ -14,7 +14,6 @@ type ServiceConfig struct {
 	ImageId     ImageId   `json:"image_id" validate:"required"`
 	DisplayName string    `json:"display_name" validate:"required"`
 	Description string    `json:"description"`
-	AutoStart   bool      `json:"auto_start"`
 }
 
 type ServiceConfigAccessor struct {


### PR DESCRIPTION
各サービスの `auto_start` を管理するためのクラスおよび config ファイルを作成しました。

システムの service についても auto_start の値だけは変更できるようにしたいので、諸々検討した結果、おそらく `auto_start` は service の config とは別軸で管理したほうがよいという結論に至りました。
ということで、 `auto_start` を各 service の config file から除いています。

おそらく以下のようなエラーがでて既存のサービスが読み込めなくなってしまうと思いますので、`docker/.local/var/lib/akira/configs/services` 以下のファイルを適宜修正お願いします :bowing_man: 

```
8:26PM WRN error while loading metadata: [5:1] unknown field "auto_start"
       2 | image_id: f7e53430-5123-4be0-a55c-fd545cc56352
       3 | display_name: Visual Studio Code Edited
       4 | description: MyVSCode2
    >  5 | auto_start: false
           ^
```