### PR TITLE
add a circular progress for service starting/stopping

### DIFF
--- a/internal/akira_frontend/src/components/ServiceList/index.tsx
+++ b/internal/akira_frontend/src/components/ServiceList/index.tsx
@@ -108,8 +108,6 @@ function PowerButton(props: PowerButtonProps) {
   );
   const powerButtonDisabled =
     props.service.status === "STARTING" || props.service.status === "STOPPING";
-
-
   const powerIcon = (() => {
     if (powerButtonDisabled) {
       return <CircularProgress/>;


### PR DESCRIPTION
circular progressをサービスのStarting/Stoppingの間に表示するようにしました。

![progress](https://user-images.githubusercontent.com/49169996/185747813-c1a26349-ed97-48e7-a358-5ef3878d4427.png)

cc: @kazyam53 