### PR TITLE
Update for scan baudrate

### DIFF
--- a/tools/python/baudrate_set.py
+++ b/tools/python/baudrate_set.py
@@ -18,6 +18,7 @@ def main() -> None:
         try:
             with DynamixelCommunicator.open(baudrate=cur) as comm:
                 control = DynamixelControlTable.TORQUE_ENABLE
+                comm.write(1, control.address, control.length, False)
                 comm.write(2, control.address, control.length, False)
                 control = DynamixelControlTable.BAUD_RATE
                 baudrate_entry = get_baudrate_control_value(TARGET_BAUDRATE)


### PR DESCRIPTION
@takuya-ikeda-tri @bonprosoft 

とりあえずbaudrate listを使って順番にスキャンすることでどの(Dynamixelが取り得る)baudrateからでもセットできるようにはなります。
実機動確済み。スキャン→書き換え自体は一瞬で終わります。

これでいいですかね〜？
このスクリプト単体で使うならいいですが、akari_clientに組み込むとなるとRuntimeErrorをpassする前提になってしまうのがちょっと気になる。