### PR TITLE
Fix env.sh to load .docker_credential by abspath

### DIFF
--- a/internal/docker/env.sh
+++ b/internal/docker/env.sh
@@ -11,7 +11,7 @@ export DOCKER_GID=$(getent group docker | cut -d: -f3)
 
 export AKARI_REPOSITORY_DIR=${REPOSITORY_ROOT}
 export AKIRA_DEV_LOCAL_DIR=${SCRIPT_DIR}/.local
-export AKIRA_DOCKER_CREDENTIAL=$(cat .docker_credential)
+export AKIRA_DOCKER_CREDENTIAL=$(cat ${SCRIPT_DIR}/.docker_credential)
 
 # for local development
 export AKIRA_TEMPLATE_DIR=${AKARI_REPOSITORY_DIR}/internal/akira_templates


### PR DESCRIPTION
すみません、 `.docker_credential` が cwd に影響を受けるようになっていたので修正しました。