### PR TITLE
Change default yolo sample ver

### DIFF
--- a/samples/depthai_sample/README.md
+++ b/samples/depthai_sample/README.md
@@ -15,6 +15,6 @@ mobilenetによる物体検出のサンプル。
 
 ### 物体検出(yolo)  
 yoloによる物体検出のサンプル。  
-`cd object_recognition`
-(yolo v4の場合)`python3 tiny-yolo.py`  
-(yolo v3の場合)`python3 tiny-yolo.py -n models/yolo-v3-tiny-tf_openvino_2021.4_6shave.blob`  
+`cd object_recognition`  
+(yolo v3の場合)`python3 tiny_yolo.py`  
+(yolo v4の場合)`python3 tiny_yolo.py -n models/yolo-v4-tiny-tf_openvino_2021.4_6shave.blob`  

--- a/samples/depthai_sample/object_recognition/tiny_yolo.py
+++ b/samples/depthai_sample/object_recognition/tiny_yolo.py
@@ -23,7 +23,7 @@ import numpy as np
 
 # Get argument first
 nnPathDefault = str(
-    (Path(__file__).parent / Path("models/yolo-v4-tiny-tf_openvino_2021.4_6shave.blob"))
+    (Path(__file__).parent / Path("models/yolo-v3-tiny-tf_openvino_2021.4_6shave.blob"))
     .resolve()
     .absolute()
 )


### PR DESCRIPTION
yolo v4のサンプルが不安定で実行中に落ちやすいため、デフォルトのyoloをv3に変更。
落ちる原因は未だ不明。検証中だがAKARI本体ごとに個体差がある。