### PR TITLE
Acquire lock in serial communication

### DIFF
--- a/sdk/akari_client/akari_client/serial/dynamixel.py
+++ b/sdk/akari_client/akari_client/serial/dynamixel.py
@@ -1,5 +1,6 @@
 import dataclasses
 import math
+import threading
 
 from ..joint_controller import RevoluteJointController
 from .dynamixel_communicator import DynamixelCommunicator
@@ -64,15 +65,22 @@ class DynamixelController(RevoluteJointController):
         self._joint_name = joint_name
         self._dynamixel_id = dynamixel_id
         self._communicator = communicator
+        self._lock = threading.Lock()
 
     def __str__(self) -> str:
         return self._joint_name
 
     def _read(self, item: DynamixelControlItem) -> int:
-        return self._communicator.read(self._dynamixel_id, item.address, item.length)
+        with self._lock:
+            return self._communicator.read(
+                self._dynamixel_id, item.address, item.length
+            )
 
     def _write(self, item: DynamixelControlItem, value: int) -> None:
-        self._communicator.write(self._dynamixel_id, item.address, item.length, value)
+        with self._lock:
+            self._communicator.write(
+                self._dynamixel_id, item.address, item.length, value
+            )
 
     def set_position_limit(self, lower_rad: float, upper_rad: float) -> None:
         """Positionの上限値と下限値を設定する。

--- a/sdk/akari_client/akari_client/serial/m5stack_communicator.py
+++ b/sdk/akari_client/akari_client/serial/m5stack_communicator.py
@@ -27,6 +27,7 @@ class M5SerialCommunicator:
         self._condition = threading.Condition()
         self._latest_msg: Optional[M5ComDict] = None
         self._thread: Optional[threading.Thread] = None
+        self._send_lock = threading.Lock()
         self._exit = False
 
         self._serial = serial.Serial(
@@ -104,7 +105,8 @@ class M5SerialCommunicator:
         return time.time() - self.reference_time
 
     def send(self, data: bytes) -> None:
-        self._serial.write(data)
+        with self._send_lock:
+            self._serial.write(data)
 
     def send_data(self, data: Dict[str, Any], sync: bool = True) -> None:
         json_data = json.dumps(data, ensure_ascii=False)


### PR DESCRIPTION
gRPCを使うようになってマルチスレッド的に AkariClient が使われることが多くなり、それによる不具合が出てきました。
ひとまず最低限のものとして、一番下のコミュニケーションレイヤーにおいて write と read でそれぞれ  lock を取ることで consistency を保つようにしたいと思います。