### PR TITLE
Add akira_controller_server to system services

### DIFF
--- a/internal/akira/service/factory.go
+++ b/internal/akira/service/factory.go
@@ -10,7 +10,13 @@ import (
 )
 
 const (
+	AkariRpcServerServiceId        ServiceId = "daa0fee2-2390-43ad-bed8-88d7365311b1"
+	AkiraControllerServerServiceId           = "e2ab28cc-5d94-11ed-9b6a-0242ac120002"
+)
+
+const (
 	AkariRpcServerServicePort                 = 51001
+	AkiraControllerServerServicePort          = 52001
 	AkariClientConfigHostRpcServer            = "client_configs.d/akari_rpc_service.json"
 	AkariClientConfigUseGrpcInBridgeContainer = "client_configs.d/grpc_bridge.json"
 	AkariClientConfigEtcPath                  = "/etc/akari/client_config.json"
@@ -32,7 +38,6 @@ func akariRpcServerSystemServiceConfig(etcDir string) (ServiceConfig, system.Cre
 		return ServiceConfig{}, system.CreateContainerOption{}, fmt.Errorf("file error: %#v", err)
 	}
 
-	id := ServiceId("daa0fee2-2390-43ad-bed8-88d7365311b1")
 	mountsConfig := []mount.Mount{
 		{
 			Type:     mount.TypeBind,
@@ -48,7 +53,7 @@ func akariRpcServerSystemServiceConfig(etcDir string) (ServiceConfig, system.Cre
 	}
 	containerPort := fmt.Sprintf("%d/tcp", AkariRpcServerServicePort)
 	serviceConfig := ServiceConfig{
-		Id:          id,
+		Id:          AkariRpcServerServiceId,
 		ImageId:     NullImageId,
 		DisplayName: "AkariRpcServer",
 		Description: "gRPC server for host devices",
@@ -62,6 +67,36 @@ func akariRpcServerSystemServiceConfig(etcDir string) (ServiceConfig, system.Cre
 		Mounts:      mountsConfig,
 		RequireRoot: true,
 		Privileged:  true,
+	}
+
+	return serviceConfig, containerOpts, nil
+}
+
+func akiraControllerServerServiceConfig(etcDir string) (ServiceConfig, system.CreateContainerOption, error) {
+	etcPath := filepath.Join(etcDir, AkariClientConfigHostRpcServer)
+	if _, err := os.Stat(etcPath); err != nil {
+		return ServiceConfig{}, system.CreateContainerOption{}, fmt.Errorf("file error: %#v", err)
+	}
+
+	mountsConfig := []mount.Mount{
+		grpcClientConfigMount(etcDir),
+	}
+	containerPort := fmt.Sprintf("%d/tcp", AkiraControllerServerServicePort)
+	serviceConfig := ServiceConfig{
+		Id:          AkiraControllerServerServiceId,
+		ImageId:     NullImageId,
+		DisplayName: "ControllerServer",
+		Description: "API server for controller page",
+	}
+	containerOpts := system.CreateContainerOption{
+		Image: "akarirobot/akira-controller-server:v1",
+		Env:   []string{},
+		Ports: map[string]int{
+			containerPort: AkiraControllerServerServicePort,
+		},
+		Mounts:          mountsConfig,
+		RequireRoot:     true,
+		BindHostGateway: true,
 	}
 
 	return serviceConfig, containerOpts, nil

--- a/internal/akira/service/service_manager.go
+++ b/internal/akira/service/service_manager.go
@@ -158,6 +158,14 @@ func (m *serviceManager) scanServices() error {
 		)
 	}
 
+	if config, containerOpts, err := akiraControllerServerServiceConfig(m.opts.EtcDir); err != nil {
+		log.Error().Msgf("error while initializing controller server: %#v", err)
+	} else {
+		registerService(
+			NewSystemService(config, containerOpts, m.opts),
+		)
+	}
+
 	for _, f := range files {
 		if f.IsDir() {
 			continue


### PR DESCRIPTION
ひとまずこんな形で akira_controller_server を起動できるようにしました。

![Screenshot from 2022-11-06 15-33-00](https://user-images.githubusercontent.com/1482237/200157625-ff408eee-2b21-41ac-b275-cd8c54d44664.png)

実は ControllerServer → AkariRpcServer には依存が発生しています。
すなわちAkariRpcServerが起動していないと ControllerServer は起動できないのですが、現状はその依存関係を扱う仕組みがないため、正しい順番で起動しないとエラーで落ちます。（この対応はひとまずTODOとさせてください。）