### PR TITLE
Avoid unnecessary execution of ansible tasks

### DIFF
--- a/setup/ansible/roles/arduino/tasks/main.yml
+++ b/setup/ansible/roles/arduino/tasks/main.yml
@@ -14,8 +14,12 @@
   synchronize:
     src: "{{ role_path }}/files/arduino/"
     dest: /home/{{ ansible_user }}/arduino/
+    checksum: true
+    times: false
+  register: upload_workspace
 
 - name: Upload app to M5Stack
   shell: platformio run --target=upload
   args:
     chdir: /home/{{ ansible_user }}/arduino/
+  when: upload_workspace.changed

--- a/setup/ansible/roles/poetry/tasks/main.yml
+++ b/setup/ansible/roles/poetry/tasks/main.yml
@@ -2,6 +2,8 @@
 - name: Install poetry
   shell: |
     curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python3 -
+  args:
+    creates: "/home/{{ ansible_user }}/.poetry"
 
 - name: Update .profile
   lineinfile:


### PR DESCRIPTION
- workspace の synchronize で不要な変更が発生しないように、一部のオプションを変更します
  - times: synchronizeのときにファイルのタイムスタンプを考慮しない
  - checksum: ファイルの時刻ベース同期ではなく、checksum同期をするようにする（i.e. 内容に差があるかをチェックして動悸するようにする）
- M5Stackへのアップロードは workspace が変更されたときだけ実行するようにします
- poetry は `/home/{{ ansible_user }}/.poetry` が存在したらインストールを省略します

これで変更がないときはすべて OK になり、changed が 0 になります。

![image](https://user-images.githubusercontent.com/1482237/200326517-ab79a611-4cf8-4a66-beac-4d71158f31f4.png)
