### PR TITLE
Set allow_downgrade option for docker install

### DIFF
--- a/setup/ansible/roles/docker/tasks/main.yml
+++ b/setup/ansible/roles/docker/tasks/main.yml
@@ -40,6 +40,7 @@
       - docker-ce-cli={{ docker_version }}
       - containerd.io
       - docker-compose-plugin
+    allow_downgrade: true
   become: true
   notify: Restart docker
 


### PR DESCRIPTION
AnsibleでDockerのバージョンを固定してインストールしています。
もしすでにインストール済みのバージョンのほうが新しい場合にはエラーが発生するため、`--allow-downgrade` オプションを指定してダウングレードできるようにします。