### PR TITLE
Fix rgb display area size

### DIFF
--- a/internal/akira_controller_server/akira_controller_server/captures/oakd_rgb.py
+++ b/internal/akira_controller_server/akira_controller_server/captures/oakd_rgb.py
@@ -14,7 +14,7 @@ class RGBCapture:
         rgb_camera = pipeline.create(dai.node.ColorCamera)
         rgb_camera.setBoardSocket(dai.CameraBoardSocket.RGB)
         rgb_camera.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
-        rgb_camera.setIspScale(4,9)
+        rgb_camera.setIspScale(4, 9)
         rgb_camera.setVideoSize(640, 480)
 
         # video setting


### PR DESCRIPTION
setIspScaleを入れないと、視野角が(1980,1020)の中心を(640,480)で切り抜いた狭い範囲になってしまうので修正
@bonprosoft 