### PR TITLE
Fix sync waiting

### DIFF
--- a/sdk/akari_client/akari_client/serial/m5stack_communicator.py
+++ b/sdk/akari_client/akari_client/serial/m5stack_communicator.py
@@ -120,7 +120,10 @@ class M5SerialCommunicator:
             return self._latest_msg is not None and self._latest_msg["is_response"]
 
         with self._condition:
-            self._condition.wait_for(_predicate)
+            while True:
+                self._condition.wait()
+                if _predicate():
+                    break
 
     def get(self) -> M5ComDict:
         now = self.current_time


### PR DESCRIPTION
Closes #116 
wait_for()だとnotify_all()を待たずに実行が進んでしまいます(前回read時の `self._latest_msg["is_response"]` がTrueなら実行が進んでしまう)。

https://docs.python.org/ja/3/library/threading.html#threading.Condition.wait_for

本変更でsync=Trueが有効になることを確認しました。