### PR TITLE
Fix/docker image

### DIFF
--- a/internal/akira_services/jupyter_lab/Dockerfile
+++ b/internal/akira_services/jupyter_lab/Dockerfile
@@ -5,10 +5,10 @@ RUN apt-get update && \
         curl \
         git \
         libgl1-mesa-dev \
-	libopencv-dev \
-	locales \
-	wget \
-    python3-pip \
+        libopencv-dev \
+        locales \
+        wget \
+        python3-pip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN localedef -f UTF-8 -i ja_JP ja_JP.UTF-8


### PR DESCRIPTION
jupyterのdockerfileをbuildしようとするとpipが使えずfailになる。

```
 > [akarirobot/akira-service-jupyter:v1  4/12] RUN pip install wheel:
#0 0.651 /bin/sh: 1: pip: not found

```
base imageをUbutnu20.04に変更したため？
pipを最初にインストールするように変更したら問題なくビルドできた。

@takuya-ikeda-tri 