### PR TITLE
Install python3-venv to create venv in service containers

### DIFF
--- a/internal/akira_services/jupyter_lab/Dockerfile
+++ b/internal/akira_services/jupyter_lab/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
         locales \
         wget \
         python3-pip \
+        python3-venv \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN localedef -f UTF-8 -i ja_JP ja_JP.UTF-8

--- a/internal/akira_services/vscode/Dockerfile
+++ b/internal/akira_services/vscode/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
         locales \
         wget \
         python3-pip \
+        python3-venv \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN localedef -f UTF-8 -i ja_JP ja_JP.UTF-8


### PR DESCRIPTION
ベースイメージが ubuntu:20.04 になったときに venv がなくなったため、 service が起動できなくなっていたようです。

ref: #117 