### PR TITLE
Make arguments optional in M5Stack.set_allout

### DIFF
--- a/sdk/akari_client/akari_client/grpc/m5stack.py
+++ b/sdk/akari_client/akari_client/grpc/m5stack.py
@@ -62,18 +62,21 @@ class GrpcM5StackClient(M5StackClient):
     def set_allout(
         self,
         *,
-        dout0: bool,
-        dout1: bool,
-        pwmout0: int,
+        dout0: Optional[bool] = None,
+        dout1: Optional[bool] = None,
+        pwmout0: Optional[int] = None,
         sync: bool = True,
     ) -> None:
-        binary_pins: Dict[str, bool] = {
-            "dout0": dout0,
-            "dout1": dout1,
-        }
-        int_pins: Dict[str, int] = {
-            "pwmout0": pwmout0,
-        }
+        binary_pins: Dict[str, bool] = {}
+        int_pins: Dict[str, int] = {}
+
+        if dout0 is not None:
+            binary_pins["dout0"] = dout0
+        if dout1 is not None:
+            binary_pins["dout1"] = dout1
+        if pwmout0 is not None:
+            int_pins["pwmout0"] = pwmout0
+
         request = m5stack_pb2.SetPinOutRequest(
             binary_pins=binary_pins,
             int_pins=int_pins,

--- a/sdk/akari_client/akari_client/m5stack_client.py
+++ b/sdk/akari_client/akari_client/m5stack_client.py
@@ -91,9 +91,9 @@ class M5StackClient(ABC):
     def set_allout(
         self,
         *,
-        dout0: bool,
-        dout1: bool,
-        pwmout0: int,
+        dout0: Optional[bool] = None,
+        dout1: Optional[bool] = None,
+        pwmout0: Optional[int] = None,
         sync: bool = True,
     ) -> None:
         """ヘッド部GPIOピンの出力をまとめて設定する。

--- a/sdk/akari_client/akari_client/serial/m5stack.py
+++ b/sdk/akari_client/akari_client/serial/m5stack.py
@@ -81,14 +81,17 @@ class M5StackSerialClient(M5StackClient):
     def set_allout(
         self,
         *,
-        dout0: bool,
-        dout1: bool,
-        pwmout0: int,
+        dout0: Optional[bool] = None,
+        dout1: Optional[bool] = None,
+        pwmout0: Optional[int] = None,
         sync: bool = True,
     ) -> None:
-        self._pin_out.dout0 = dout0
-        self._pin_out.dout1 = dout1
-        self._pin_out.pwmout0 = pwmout0
+        if dout0 is not None:
+            self._pin_out.dout0 = dout0
+        if dout1 is not None:
+            self._pin_out.dout1 = dout1
+        if pwmout0 is not None:
+            self._pin_out.pwmout0 = pwmout0
 
         self._write_pin_out(sync=sync)
 


### PR DESCRIPTION
Closes #115 

`set_allout` のインターフェイスを本PRのように変更しても良いのであれば、これが一番順当な修正な気がしましたがいかがでしょう？