### PR TITLE
Add GitHub actions to build and push akira docker images

### DIFF
--- a/.github/actions/build-akira-images/action.yml
+++ b/.github/actions/build-akira-images/action.yml
@@ -1,0 +1,25 @@
+name: 'Build akira images'
+description: 'Build akira images'
+inputs:
+  compose-path:
+    description: 'A path to docker-compose file'
+    required: true
+  dryrun:
+    description: 'Do not push images if the value is set'
+    required: true
+env:
+  AKIRA_IMAGE_TAG: v1
+runs:
+  using: 'composite'
+  steps:
+    - name: Build images
+      run: |
+        source internal/docker/env.sh
+        docker compose -f ${{ inputs.compose-path }} build
+      shell: bash
+    - name: Push images
+      run: |
+        source internal/docker/env.sh
+        docker compose -f ${{ inputs.compose-path }} push
+      shell: bash
+      if: ${{ ! fromJson(inputs.dryrun) }}

--- a/.github/workflows/update-akira-images.yml
+++ b/.github/workflows/update-akira-images.yml
@@ -1,0 +1,41 @@
+name: Update akira docker images
+on:
+  workflow_dispatch:
+    dryrun:
+      type: boolean
+      description: 'Do not push images if the value is set'
+      default: false
+      required: false
+
+jobs:
+  update-akira-image:
+    name: Update docker images
+    timeout-minutes: 30
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        lfs: false
+    - name: Locate fake files
+      run: |
+        echo "none" > internal/docker/.docker_credential
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push akira images
+      uses: ./.github/actions/build-akira-images
+      with:
+        compose-path: internal/docker/docker-compose.dev.yml
+        dryrun: ${{ github.event_name != 'workflow_dispatch' || github.events.inputs.dryrun }}
+    - name: Build and push akira-service images
+      uses: ./.github/actions/build-akira-images
+      with:
+        compose-path: internal/akira_services/docker-compose.image.yml
+        dryrun: ${{ github.event_name != 'workflow_dispatch' || github.events.inputs.dryrun }}
+    - name: Post a notification
+      run: |
+        curl -X POST \
+          --data-urlencode 'payload={"text": "<!channel> Published new akira images (commit hash: ${{ github.sha }})"}' \
+          ${{ secrets.AKIRA_PUSH_NOTIFICATION_ENDPOINT }}


### PR DESCRIPTION
このPRがマージされたら、`Actions` タブから手動で trigger してあげることでかんたんに docker image がデプロイできるようになります。