### PR TITLE
Feature/boot img

### DIFF
--- a/setup/m5_sd/boot/1.jpg
+++ b/setup/m5_sd/boot/1.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aa865404eeb7d0a1bee5492ee7e8ca7bd1eb64102c24aa5b0bc116e6c3bcd99
+size 950

--- a/setup/m5_sd/boot/10.jpg
+++ b/setup/m5_sd/boot/10.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b421d902d78590cdb39982e91f43cd215208d8cc3af6a7c4a57ef2fa1947cdb
+size 2282

--- a/setup/m5_sd/boot/11.jpg
+++ b/setup/m5_sd/boot/11.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b31631eda3cb0f31b094da442a38a65a9e783eb8ebab3a53474c093680653b5
+size 2360

--- a/setup/m5_sd/boot/12.jpg
+++ b/setup/m5_sd/boot/12.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1494784652cd7d86ad43bd08f1a80d437b93739fbddd549958b2a7228fb95e71
+size 2411

--- a/setup/m5_sd/boot/13.jpg
+++ b/setup/m5_sd/boot/13.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:015d09d99e91007526e32696f70b7642f9b57e2f530720c353cd8a1e4a7e4eea
+size 2456

--- a/setup/m5_sd/boot/14.jpg
+++ b/setup/m5_sd/boot/14.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d94042244ecec0ce2c0ebe0a4211a2f829b4cd7fe634a05474ff20cd0a4dc94
+size 2721

--- a/setup/m5_sd/boot/15.jpg
+++ b/setup/m5_sd/boot/15.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33e49361eca6a6fbbc9ac0a6e70949ef9bbde09c56a320729edd67b134fd1ba4
+size 2945

--- a/setup/m5_sd/boot/16.jpg
+++ b/setup/m5_sd/boot/16.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c275da8a3951b28a689b5d768eb03ed69a2583203f5e1d774cb61ec6496a6706
+size 3044

--- a/setup/m5_sd/boot/17.jpg
+++ b/setup/m5_sd/boot/17.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6f15b5e2893403dabcd58429bced62013090e391caa24fa6bdba6341028a6bc
+size 3026

--- a/setup/m5_sd/boot/18.jpg
+++ b/setup/m5_sd/boot/18.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f6d11387f49987e9bff78d92d36f8efed2dcb95182784f3f9941ba3606ff6b6
+size 3059

--- a/setup/m5_sd/boot/19.jpg
+++ b/setup/m5_sd/boot/19.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:862ed6643f3fadd7bf04da03ff188e50b423eeeac1534ed2ecf12b31e007e4ef
+size 2998

--- a/setup/m5_sd/boot/2.jpg
+++ b/setup/m5_sd/boot/2.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa43782987c1f5c142fc11cf343a77d6befdae496e7dc859cac2705018856bc9
+size 978

--- a/setup/m5_sd/boot/20.jpg
+++ b/setup/m5_sd/boot/20.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81d9b80be0482b454277a152a7bcdc9792b260ebf8aabd912b31c9c6f1a0e988
+size 3019

--- a/setup/m5_sd/boot/21.jpg
+++ b/setup/m5_sd/boot/21.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ab7ce17ac7f7fb9a9baea4691149662c17ddc431e3671dd6309031a9d4c414d
+size 3011

--- a/setup/m5_sd/boot/22.jpg
+++ b/setup/m5_sd/boot/22.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dfe790f0e442ecef963f86db310b0c203f4c285248314c34761078544092694
+size 3192

--- a/setup/m5_sd/boot/23.jpg
+++ b/setup/m5_sd/boot/23.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b657303d6058d2677dfd5fc9ded2b3f66e44c472328104228fda5391a82c51d2
+size 3222

--- a/setup/m5_sd/boot/24.jpg
+++ b/setup/m5_sd/boot/24.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa7afc58a720ae55fe8a04750929ddc20ac300a71578feb6b631147d1cf44076
+size 3357

--- a/setup/m5_sd/boot/25.jpg
+++ b/setup/m5_sd/boot/25.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a41c312e1d9677ad8251a19ba5d2572e55f5c964fdb47fad314840c3c8bfdc17
+size 3574

--- a/setup/m5_sd/boot/26.jpg
+++ b/setup/m5_sd/boot/26.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8deb96ec7e7b73d9367992b811eb834899145209e72901e4d9ec7df0d7a9acf8
+size 3672

--- a/setup/m5_sd/boot/27.jpg
+++ b/setup/m5_sd/boot/27.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf652b3176104e7bdaac0f5e6eb39e7e428c6a446b96e0ac90b11d37c42bc7fb
+size 3617

--- a/setup/m5_sd/boot/28.jpg
+++ b/setup/m5_sd/boot/28.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72cd4081aff633dd71e03cbc6907445eb09eae6e6af6066de643ab3b06e3a9e4
+size 3598

--- a/setup/m5_sd/boot/29.jpg
+++ b/setup/m5_sd/boot/29.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc91cfefce0e621715df4a2f70ea09f430e56e07dad31faf139e0dbc179bde91
+size 3574

--- a/setup/m5_sd/boot/3.jpg
+++ b/setup/m5_sd/boot/3.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa43782987c1f5c142fc11cf343a77d6befdae496e7dc859cac2705018856bc9
+size 978

--- a/setup/m5_sd/boot/30.jpg
+++ b/setup/m5_sd/boot/30.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ec56f0886d9cedafec97a067ae075bb251cb490b8389410111fffb6ddbe82e9
+size 4640

--- a/setup/m5_sd/boot/31.jpg
+++ b/setup/m5_sd/boot/31.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73bb2acc261124daec907e2eb772e93fbebe74d204a158e1d725b1276ffefc0f
+size 4541

--- a/setup/m5_sd/boot/32.jpg
+++ b/setup/m5_sd/boot/32.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c34b370879730d68e290e40fbd3f9ab274c3a80c89a013c122249468764e640e
+size 5218

--- a/setup/m5_sd/boot/33.jpg
+++ b/setup/m5_sd/boot/33.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2884f6bc5cd1f68119f5e74d83a808cdcee8f24b5ede1f86a70fdf222319085e
+size 5163

--- a/setup/m5_sd/boot/34.jpg
+++ b/setup/m5_sd/boot/34.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c36f4ccf057338853ab5ac1165c1b11110544e8e6f2735ce218351e6bb96e884
+size 5414

--- a/setup/m5_sd/boot/35.jpg
+++ b/setup/m5_sd/boot/35.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d229d6605b6a2507bec6275a3491eef9d00eaebbbc571694afb74fbe741fa30b
+size 4696

--- a/setup/m5_sd/boot/36.jpg
+++ b/setup/m5_sd/boot/36.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:522a35207f4be8044006d2c13c6392514d0e49af273539cc34d56a4283431abf
+size 4864

--- a/setup/m5_sd/boot/37.jpg
+++ b/setup/m5_sd/boot/37.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9910446a8ad982a17840b920edebaab2bf586c3c56887fc2a12380e4b4b0a1f
+size 5029

--- a/setup/m5_sd/boot/38.jpg
+++ b/setup/m5_sd/boot/38.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d71ef83cd3ed96260228f2a8642eee5841009c4a3f18a69339e5dcb989348175
+size 5275

--- a/setup/m5_sd/boot/39.jpg
+++ b/setup/m5_sd/boot/39.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17d6c1a50882b1c4bc822da3a475466092e94b866fdf31e18b69a36f3a2b33df
+size 5141

--- a/setup/m5_sd/boot/4.jpg
+++ b/setup/m5_sd/boot/4.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa43782987c1f5c142fc11cf343a77d6befdae496e7dc859cac2705018856bc9
+size 978

--- a/setup/m5_sd/boot/40.jpg
+++ b/setup/m5_sd/boot/40.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:518cbad9ece96d523b8d67e8a8aa8ca37a4ebefc4b3bde2c469cf6102b333573
+size 4601

--- a/setup/m5_sd/boot/41.jpg
+++ b/setup/m5_sd/boot/41.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc90c4135357ab5d78f6e9bf2ac7ec73054177a91e1bf1cf7908b4f17e4c2bcd
+size 4567

--- a/setup/m5_sd/boot/42.jpg
+++ b/setup/m5_sd/boot/42.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c9bc10460e31572e2a1944676be5767787979d1c8e6efd9a8a8a8e60f600eff
+size 4594

--- a/setup/m5_sd/boot/43.jpg
+++ b/setup/m5_sd/boot/43.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:095e555e8002a43f3cf64dab87724309d726dcac93cdaaab797be2edd99984ea
+size 4584

--- a/setup/m5_sd/boot/44.jpg
+++ b/setup/m5_sd/boot/44.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29e327ab9459cc00bef4da2e712000be336993277a9bdc3064c633409ad6a058
+size 4584

--- a/setup/m5_sd/boot/45.jpg
+++ b/setup/m5_sd/boot/45.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bef590971abefb101b1fa0074da3fee9db8f4c741155801d56482ce49bbc8405
+size 4588

--- a/setup/m5_sd/boot/46.jpg
+++ b/setup/m5_sd/boot/46.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f7a2b11e13c82e0fdf6be09297e4508ec479b1f1a3bfc1b46f58f067cb5c8b
+size 4245

--- a/setup/m5_sd/boot/47.jpg
+++ b/setup/m5_sd/boot/47.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f7a2b11e13c82e0fdf6be09297e4508ec479b1f1a3bfc1b46f58f067cb5c8b
+size 4245

--- a/setup/m5_sd/boot/48.jpg
+++ b/setup/m5_sd/boot/48.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f7a2b11e13c82e0fdf6be09297e4508ec479b1f1a3bfc1b46f58f067cb5c8b
+size 4245

--- a/setup/m5_sd/boot/5.jpg
+++ b/setup/m5_sd/boot/5.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa43782987c1f5c142fc11cf343a77d6befdae496e7dc859cac2705018856bc9
+size 978

--- a/setup/m5_sd/boot/6.jpg
+++ b/setup/m5_sd/boot/6.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b31fe89ae6408b951067b9686fc1478b22d52c55f02e3f9c64568e8fc98b7d7
+size 1165

--- a/setup/m5_sd/boot/7.jpg
+++ b/setup/m5_sd/boot/7.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c24299d8a826a719223252b513619758b03931889ddac0c5d66dfe9cdedd1e7
+size 1250

--- a/setup/m5_sd/boot/8.jpg
+++ b/setup/m5_sd/boot/8.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e216dda7dff3e3ef0c89a919bef0725f56db8371b250c665b8e8be058451c31e
+size 1449

--- a/setup/m5_sd/boot/9.jpg
+++ b/setup/m5_sd/boot/9.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdf92aa3d8c3aa4505706c3e00119eec918775f5aa7692228f5f285c17997e78
+size 1715

--- a/setup/m5_sd/logo.jpg
+++ b/setup/m5_sd/logo.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ca6362e3324cdf289bd5d1b9251c09c6c015f127ae367ab918667742303ebec
-size 89607
+oid sha256:fd27988c27e53ec9c777d2dfebe616f04f21299fbb7e7f562e5445c93b66d779
+size 18233

--- a/setup/m5_sd/logo320.jpg
+++ b/setup/m5_sd/logo320.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf817a0b8b17547fed08b4fc52b45429f8efbf7e4cf9142862ecfb5abc22fe71
-size 10219
+oid sha256:b70da8cfb245f371ccea3e78c46746bd2c9ac65fa49bf73caec3eca58564fea3
+size 9477


### PR DESCRIPTION
@takuya-ikeda-tri 
https://user-images.githubusercontent.com/36440835/209140351-3ca2bca9-5181-4c48-8192-09d801f33da6.mp4

起動画面の変更と起動アニメーションの追加を行いました。
・M5起動直後の待機画面の画像を変更。画像描画後にM5のソフトのバージョン文字列を上から描画することで、今書かれてるM5のソフトが分かるようにしました。サポート用
・RpcとつながるとAKARIのロゴのアニメーションが再生されます。drawImgを連打するだけなのでパラパラ漫画の要領で画像ファイルを1コマずつ上げる羽目になっています。gif再生がベストだけど、既存の仕組みとの共存が難しそうなので一旦保留。