### PR TITLE
Ignore error of pulling akira docker image

### DIFF
--- a/setup/ansible/roles/akira/templates/akira.service.j2
+++ b/setup/ansible/roles/akira/templates/akira.service.j2
@@ -6,7 +6,7 @@ Requires=docker.service
 [Service]
 EnvironmentFile=/etc/akira/daemon.d/override.env
 Environment=AKIRA_COMPOSE_FILE=/etc/akira/daemon.d/docker-compose.v1.yml
-ExecStartPre=/etc/akira/daemon.d/env.sh /usr/bin/docker compose -f ${AKIRA_COMPOSE_FILE} pull
+ExecStartPre=-/etc/akira/daemon.d/env.sh /usr/bin/docker compose -f ${AKIRA_COMPOSE_FILE} pull
 ExecStart=/etc/akira/daemon.d/env.sh /usr/bin/docker compose -f ${AKIRA_COMPOSE_FILE} up --force-recreate
 ExecStop=/etc/akira/daemon.d/env.sh /usr/bin/docker compose -f ${AKIRA_COMPOSE_FILE} down
 


### PR DESCRIPTION
akira sevrice起動時に docker pull に失敗した場合、現状だと akira 全体を起動することができません。
ネットワークがない状況下で使用する場合にこの仕様だと開発が厳しいため、docker pullに失敗した場合でも起動を試みるように変更します。（ネットワークがない場合には、ローカルに存在する最新のイメージを使うようになるイメージです）