### PR TITLE
Try launching container services if akira fails to pull the latest image

### DIFF
--- a/internal/akira/service/container.go
+++ b/internal/akira/service/container.go
@@ -82,7 +82,8 @@ func (p *ServiceContainer) createContainer() (system.ContainerId, error) {
 	}
 	err = p.d.PullImage(p.containerConfig.Image)
 	if err != nil {
-		return "", fmt.Errorf("error while pulling image (ref: %#v): %#v)", p.containerConfig.Image, err)
+		// NOTE: Try launching service container if it fails to pull the latest docker image (e.g. no network connection)
+		p.logger.Warn().Msgf("failed to pull image (ref: %#v): %#v)", p.containerConfig.Image, err)
 	}
 
 	containerId, err := p.d.CreateContainer(p.containerConfig)


### PR DESCRIPTION
Ref: #148 

同様の理由で akira service で image の pull に失敗した場合でもサービスを起動するように試みます。