### PR TITLE
Fix projectject card layout

### DIFF
--- a/internal/akira_frontend/src/pages/Projects/index.tsx
+++ b/internal/akira_frontend/src/pages/Projects/index.tsx
@@ -47,12 +47,16 @@ export function Projects() {
     );
   } else {
     element = (
-      <Stack spacing={2} sx={{ margin: 1 }} direction="row">
-        <NewProjectButtonCard />
+      <Grid container spacing={2} sx={{ margin: 1 }}>
+        <Grid item xs="auto">
+          <NewProjectButtonCard />
+        </Grid>
         {data?.projects?.map((p) => (
-          <ProjectCard key={p.id} project={p} />
+          <Grid item xs="auto">
+            <ProjectCard key={p.id} project={p} />
+          </Grid>
         ))}
-      </Stack>
+      </Grid>
     );
   }
 


### PR DESCRIPTION
プロジェクト数が増えると、カード表示が改行せず横方向に伸び続けていくのを修正
変更前
![Screenshot from 2023-01-07 18-34-59](https://user-images.githubusercontent.com/36440835/211144217-b04b7398-1b5e-4d2d-9480-a236964cbb51.png)
変更後
![Screenshot from 2023-01-07 18-34-08](https://user-images.githubusercontent.com/36440835/211144169-56c1e577-e0fc-4509-bef7-683aeecbd832.png)
