### PR TITLE
Fix/m5 restart

### DIFF
--- a/sdk/akari_client/akari_client/serial/m5stack.py
+++ b/sdk/akari_client/akari_client/serial/m5stack.py
@@ -169,7 +169,7 @@ class M5StackSerialClient(M5StackClient):
         data = {"com": CommandId.RESETM5}
         self._communicator.send_data(data, sync=False)
         self._pin_out.reset()
-        time.sleep(2)
+        time.sleep(4)
         self._start_m5()
 
     def get(self) -> M5ComDict:


### PR DESCRIPTION
rpc_serverが再起動した時にM5の再スタートに失敗する問題を修正。
M5の起動直後のwaiting画面でバージョンを描画するようにしたため、この処理を終えてrpc_serverからの通信開始の信号受信待ちになるまでの時間が伸びて、rpc_serverからの送信タイミングに間に合わなくなったためと思います。
便宜的にsleep時間を伸ばして対応、動作OKなのを確認しましたが、将来的にはちゃんとrpc_server側でM5の通信開始を判定するようにしないといけないと思います。
この辺の仕組みはM5と合わせてやはり見直しですね。