### PR TITLE
Separate akira image pull process to update-akira service

### DIFF
--- a/setup/ansible/roles/akira/tasks/main.yml
+++ b/setup/ansible/roles/akira/tasks/main.yml
@@ -57,6 +57,14 @@
   become: true
   notify:
     - Restart akira.service
+- name: Install update-akira.service
+  template:
+    src: "{{ role_path }}/templates/update-akira.service.j2"
+    dest: /etc/systemd/system/update-akira.service
+    mode: "0644"
+  become: true
+  notify:
+    - Restart akira.service
 - name: Enable akira.service
   systemd:
     name: akira.service

--- a/setup/ansible/roles/akira/templates/update-akira.service.j2
+++ b/setup/ansible/roles/akira/templates/update-akira.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Update Akira daemon
+After=docker.service
+Requires=docker.service
+
+[Service]
+EnvironmentFile=/etc/akira/daemon.d/override.env
+Environment=AKIRA_COMPOSE_FILE=/etc/akira/daemon.d/docker-compose.v1.yml
+ExecStart=/etc/akira/daemon.d/env.sh /usr/bin/docker compose -f ${AKIRA_COMPOSE_FILE} pull
+
+Type=oneshot
+User={{ ansible_user }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
すみません、これは実機が必要なので試せていないです :dogeza:

Akiraのイメージをアップデートするのを手動更新にしました。

Akariにログインして
```sh
sudo systemctl start update-akira
```
を実行するとイメージの更新が行われるはずです。
また初回Ansible適用時はイメージが何もないので、ansible実行後に**再起動をしてから**必ずこのコマンドを行うのが必要になると思っています。

@kazyam53 一旦カジュアルに `sudo systemctl start update-akira` を実行して、実行完了後に `sudo systemctl status update-akira` がエラーになっていないかどうかを確認していただくことは可能でしょうか？お手数おかけします。