### PR TITLE
Set JUPYTER_PREFER_ENV_PATH to prevent from uid check

### DIFF
--- a/internal/akira_services/jupyter_lab/Dockerfile
+++ b/internal/akira_services/jupyter_lab/Dockerfile
@@ -28,6 +28,7 @@ RUN pip install \
         /resources/sdk/akari_client[depthai] \
         /resources/sdk/akari_proto/
 COPY internal/akira_services/jupyter_lab/entrypoint.sh /entrypoint.sh
+ENV JUPYTER_PREFER_ENV_PATH=1
 
 RUN mkdir -p /host_var && chmod 777 /host_var
 WORKDIR /app


### PR DESCRIPTION
JupyterLabの起動に失敗する件ですが、ログを見た感じjupyter core が更新されて起動プロセス中に login user をチェックするようになったことが原因のようです。
（実はいまはDockerコンテナ全体をユーザー権限で動かすためにいろいろと細かいことをやっていて、一部のユーザーエントリーを調べる関係のAPIが使えない状況です）

https://github.com/jupyter/jupyter_core/blob/98ab1ef453956333a85bb6eee494ad0a9bab2c02/jupyter_core/paths.py#L98-L106

ひとまずこの関数の呼び出しを回避するために、環境変数をセットするようにしました。
動作確認済みです。