### PR TITLE
Use projects page as the top page

### DIFF
--- a/internal/akira_frontend/src/layouts/MainLayout/Sidebar/index.tsx
+++ b/internal/akira_frontend/src/layouts/MainLayout/Sidebar/index.tsx
@@ -14,7 +14,6 @@ import {
   Switch,
 } from "@mui/material";
 import { Link, NavLink } from "react-router-dom";
-import DashboardIcon from "@mui/icons-material/Dashboard";
 import WorkIcon from "@mui/icons-material/Work";
 import AppsIcon from "@mui/icons-material/Apps";
 import SportsEsportsIcon from "@mui/icons-material/SportsEsports";
@@ -27,7 +26,7 @@ import {
   useDarkmodeValue,
   useSetDarkmodeValue,
 } from "../../../contexts/DarkmodeContext";
-import { purple } from "@mui/material/colors";
+import { grey, purple } from "@mui/material/colors";
 
 type Props = {};
 
@@ -38,6 +37,11 @@ const Drawer = styled(MuiDrawer)(() => ({
     width: SidebarWidth,
   },
 }));
+const SidebarListItemButton = styled(ListItemButton)(({ theme }) => ({
+  "&.active": {
+    background: theme.palette.mode === "dark" ? grey[800] : grey[300],
+  },
+})) as typeof ListItemButton;
 
 function SidebarItems() {
   return (
@@ -61,31 +65,25 @@ function SidebarItems() {
           />
         </Button>
       </ListItem>
-      <ListItemButton component={NavLink} to="/">
-        <ListItemIcon>
-          <DashboardIcon />
-        </ListItemIcon>
-        <ListItemText primary="Dashboard" />
-      </ListItemButton>
-      <ListItemButton component={NavLink} to="/projects">
+      <SidebarListItemButton component={NavLink} to="/projects">
         <ListItemIcon>
           {" "}
           <WorkIcon />
         </ListItemIcon>
         <ListItemText primary="Projects" />
-      </ListItemButton>
-      <ListItemButton component={NavLink} to="/services">
+      </SidebarListItemButton>
+      <SidebarListItemButton component={NavLink} to="/services">
         <ListItemIcon>
           <AppsIcon />
         </ListItemIcon>
         <ListItemText primary="Services" />
-      </ListItemButton>
-      <ListItemButton component={NavLink} to="/controller">
+      </SidebarListItemButton>
+      <SidebarListItemButton component={NavLink} to="/controller">
         <ListItemIcon>
           <SportsEsportsIcon />
         </ListItemIcon>
         <ListItemText primary="Controller" />
-      </ListItemButton>
+      </SidebarListItemButton>
     </List>
   );
 }

--- a/internal/akira_frontend/src/pages/HomeDashboard/index.tsx
+++ b/internal/akira_frontend/src/pages/HomeDashboard/index.tsx
@@ -1,5 +1,0 @@
-type Props = {};
-
-export function HomeDashboard(props: Props) {
-  return <>Top page</>;
-}

--- a/internal/akira_frontend/src/routes/index.tsx
+++ b/internal/akira_frontend/src/routes/index.tsx
@@ -1,6 +1,5 @@
 import { Navigate, RouteObject } from "react-router-dom";
 import { MainLayout } from "../layouts/MainLayout";
-import { HomeDashboard } from "../pages/HomeDashboard";
 import { Projects } from "../pages/Projects";
 import { ProjectsCreate } from "../pages/Projects/Create";
 import { ProjectsEdit } from "../pages/Projects/Edit";
@@ -15,7 +14,7 @@ export const AppRoute: RouteObject = {
   children: [
     {
       path: "",
-      element: <HomeDashboard />,
+      element: <Navigate to="/projects" />,
     },
     {
       path: "/projects",


### PR DESCRIPTION
Topページを消してプロジェクトページをデフォルトで表示するようにしました。

また、混ぜてしまって申し訳ないのですが、現在表示中のページをサイドバーでハイライトするようにしました。

![Screenshot from 2023-02-08 20-22-41](https://user-images.githubusercontent.com/1482237/217717502-a29e7983-339e-4aa8-9363-6ca98c0462aa.png)
![Screenshot from 2023-02-08 20-22-57](https://user-images.githubusercontent.com/1482237/217717508-68ac5c30-a656-4fab-b436-9ccc7082fb1f.png)

