### PR TITLE
Set become:true for platformio operations

### DIFF
--- a/setup/ansible/roles/arduino/tasks/main.yml
+++ b/setup/ansible/roles/arduino/tasks/main.yml
@@ -10,6 +10,15 @@
     name: platformio
   become: true
 
+# When the playbook is executed for the first time,
+# user might not belong to the dialout group in the session.
+# That would cause errors on `platformio run`, since it needs
+# to perform write actions on `/dev/ttyUSB`, which requires
+# dialout group to write.
+#
+# As such, set `become: true` for the platformio operations
+# to avoid the problem.
+
 - name: Copy platformio workspace
   synchronize:
     src: "{{ role_path }}/files/arduino/"
@@ -17,9 +26,11 @@
     checksum: true
     times: false
   register: upload_workspace
+  become: true
 
 - name: Upload app to M5Stack
   shell: platformio run --target=upload
   args:
     chdir: "{{ ansible_env.HOME }}/arduino/"
   when: upload_workspace.changed
+  become: true


### PR DESCRIPTION
## 問題

- arduino role のなかで `platformio run --target=upload` を実行しており、これは `/dev/ttyUSB*` に対して書き込みを行う
- `/dev/ttyUSB*` は `root:dialout` になっており、ansible のユーザーが dialout に所属していなければ（sudo なしでは）実行できない
- `common` で ansible のユーザーを `dialout` に追加するタスクを実行しているが、再起動（正確にはセッションの再ログイン）を行わないとユーザーが `dialout` グループに所属しないため、書き込みに失敗する

## 対策
1. `become: true` を与えて sudo 権限をもって platformio を実行する
    - pros: 再起動不要。1回の ansible 実行で完結する
    - cons: `~/arduino` ディレクトリの一部に root:root なファイルができてしまう
2. playbook を中断して再起動を促す + 2回目で platformio を実行する
    - pros: （パーミッション周りが）最もきれい
    - cons: 再起動が必要
3. ~`reboot` ステップを挟む~ `-c local` を使ったときに動かないためNG

---

上記 pros/cons を考えて、ここでは 1 を実装してみました。
2 は以下のような step を挟むことで実装できると考えましたが、Ansible 上では `getenv` を呼び出しているのか、`id` で `dialout` に所属していなくても `test_user_dialout is not changed` になってしまいます。

```yaml
- name: Check if user belongs to dialout group
  user:
    name: '{{ ansible_env.USER }}'
    groups: dialout
    append: yes
  check_mode: true
  become: true
  register: test_user_dialout

- assert:
    that:
      - "test_user_dialout is not changed"
    fail_msg: "ユーザー: {{ ansible_env.USER }} が dialout グループに属していません。再起動して再度 Ansible を実行してください。"
```