### PR TITLE
Relax dependency version constraints of akari_client

### DIFF
--- a/sdk/akari_client/setup.py
+++ b/sdk/akari_client/setup.py
@@ -34,10 +34,10 @@ setup(
             "protobuf==3.19.3",
         ],
         "depthai": [
-            "matplotlib==3.6.2",
-            "depthai==2.19.1.0",
+            "matplotlib",
+            "depthai",
             "opencv-python",
-            "blobconverter==1.3.0",
+            "blobconverter",
         ],
     },
 )


### PR DESCRIPTION
depthai の他のバージョン依存についても同様に緩和させました。
grpcとprotobufについては、おそらく alaro_proto を生成するのに使ったものと互換性のあるバージョンを使わないといけないと考えていて、どこまで互換性があるか調べられていないため、現状そのままとしています。