### PR TITLE
Fix controller server opencv error

### DIFF
--- a/internal/akira_controller_server/setup.py
+++ b/internal/akira_controller_server/setup.py
@@ -16,7 +16,7 @@ setup(
         "fastapi==0.86.0",
         "grpcio==1.44.0",
         "numpy==1.23.4",
-        "opencv-python==4.7.0.72",
+        "opencv-python-headless==4.7.0.72",
         "protobuf==3.19.3",
         "uvicorn==0.19.0",
     ],


### PR DESCRIPTION
controller_serverが起動エラーになるのを修正しました。

`Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/resources/sdk/akira_controller_server/akira_controller_server/cli/__main__.py", line 6, in <module>
    from .. import media, server
  File "/resources/sdk/akira_controller_server/akira_controller_server/media.py", line 9, in <module>
    import cv2
  File "/usr/local/lib/python3.10/dist-packages/cv2/__init__.py", line 181, in <module>
    bootstrap()
  File "/usr/local/lib/python3.10/dist-packages/cv2/__init__.py", line 153, in bootstrap
    native_module = importlib.import_module("cv2")
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ImportError: libGL.so.1: cannot open shared object file: No such file or directory`

Dockerでcv2を呼んだ時のエラーらしいです。
https://cocoinit23.com/docker-opencv-importerror-libgl-so-1-cannot-open-shared-object-file/
https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo

前回僕が正しく動確できていなかった可能性が高いです。すいません…。(localでtestする時にpullImageをコメントアウトしていなかった)
とりあえず
①Dockerfileに下記を追記
RUN apt-get update && apt-get upgrade -y
RUN apt-get install -y libgl1-mesa-dev
②opencv-python-headlessに戻す
の選択肢がありそうですが、Imageサイズ考慮してcontroller-serverだけheadlessに戻そうかと思いますがいかがでしょうか？

headlessに変更してcontrollerが起動することは実機確認しました。