### PR TITLE
Create akari_projects directory at akira ansible role

### DIFF
--- a/setup/ansible/roles/akira/files/daemon.d/env.sh
+++ b/setup/ansible/roles/akira/files/daemon.d/env.sh
@@ -4,6 +4,6 @@ export HOST_GID=$(id -g)
 export HOST_UID=$(id -u)
 export DOCKER_GID=$(getent group docker | cut -d: -f3)
 export AKIRA_IMAGE_TAG=${AKIRA_IMAGE_TAG:-v1}
-export AKIRA_PROJECT_DIR=${HOME}/projects
+export AKIRA_PROJECT_DIR=${HOME}/akari_projects
 
 exec "$@"

--- a/setup/ansible/roles/akira/tasks/main.yml
+++ b/setup/ansible/roles/akira/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Create project directory to HOME
+  file:
+    path: {{ ansible_env.HOME }}/akari_projects
+    state: directory
+    mode: "0755"
+  become: true
+
 - name: Create /etc/akira
   file:
     path: /etc/akira


### PR DESCRIPTION
`akari_projects` ディレクトリが存在しないことによりsystemd 起動が失敗していた問題を修正しました。