### PR TITLE
Fix akari_project dir create

### DIFF
--- a/setup/ansible/roles/akira/tasks/main.yml
+++ b/setup/ansible/roles/akira/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Create project directory to HOME
   file:
-    path: {{ ansible_env.HOME }}/akari_projects
+    path: "{{ ansible_env.HOME }}/akari_projects"
     state: directory
     mode: "0755"
-  become: true
+  become: false
 
 - name: Create /etc/akira
   file:

--- a/setup/ansible/roles/akira/tasks/main.yml
+++ b/setup/ansible/roles/akira/tasks/main.yml
@@ -4,7 +4,6 @@
     path: "{{ ansible_env.HOME }}/akari_projects"
     state: directory
     mode: "0755"
-  become: false
 
 - name: Create /etc/akira
   file:


### PR DESCRIPTION
pathの記述が間違っていてエラーになるのを修正。
またbecomeがfalseでないとweb consoleがakari_projects内にプロジェクトを作れません。