### PR TITLE
Add usb reset handlers

### DIFF
--- a/setup/ansible/roles/m5stack/handlers/main.yml
+++ b/setup/ansible/roles/m5stack/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Reset M5Stack Gray
+  shell: |
+    usb_modeswitch -v 0x10c4 -p 0xea60 --reset-usb
+  become: yes
+  
+- name: Reset M5Stack Basic v2.6
+  shell: |
+    usb_modeswitch -v 0x1a86 -p 0x55d4 --reset-usb
+  become: yes

--- a/setup/ansible/roles/m5stack/tasks/main.yml
+++ b/setup/ansible/roles/m5stack/tasks/main.yml
@@ -6,7 +6,9 @@
     mode: "644"
     line: 'KERNEL=="ttyUSB*",  ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", ATTRS{product}=="CP2104 USB to UART Bridge Controller" SYMLINK+="ttyUSB_M5Stack"'
   become: yes
-  notify: Reload udev rules
+  notify: 
+    - Reload udev rules
+    - Reset M5Stack Gray
 
 - name: Configure udev for M5Stack Basic v2.6
   lineinfile:
@@ -15,4 +17,6 @@
     mode: "644"
     line: 'KERNEL=="ttyACM[0-9]*", SUBSYSTEM=="tty", ACTION=="add", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="55d4", SYMLINK+="ttyUSB_M5Stack"'
   become: yes
-  notify: Reload udev rules
+  notify: 
+    - Reload udev rules
+    - Reset M5Stack Basic v2.6


### PR DESCRIPTION
ansibleでM5のソフト書き込みに失敗するのを修正しました。
udev rulesをreloadした後に、M5のUSB接続をリセットするhandlerを追加しています。