### PR TITLE
Check service alive every 10 seconds

### DIFF
--- a/internal/akira/service/service_manager.go
+++ b/internal/akira/service/service_manager.go
@@ -86,7 +86,7 @@ func NewServiceManager(opts ServiceManagerOptions) (ServiceManager, error) {
 	go func() {
 		for {
 			m.CheckAlive()
-			time.Sleep(CheckAlivePeriodSeconds)
+			time.Sleep(CheckAlivePeriodSeconds * time.Second)
 		}
 	}()
 


### PR DESCRIPTION
すみません、秒指定が抜けていて 10 nsec で container の死活監視処理が実行されていました。
（現状 akira の動作が重くなっている原因の1つな気がします...！）