### PR TITLE
Fix numpy ver

### DIFF
--- a/sdk/akari_client/setup.py
+++ b/sdk/akari_client/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=[
         "dynamixel_sdk",
         "pydantic>=1.5,<2.0",
+        "numpy==1.26.4",
     ],
     package_data={"akari_client": ["py.typed"]},
     extras_require={


### PR DESCRIPTION
numpy2.0.0のリリースにより、バージョン指定しないと既存アプリが起動しなくなっています…。