### PR TITLE
Fix v4l2loopback

### DIFF
--- a/setup/ansible/roles/common/tasks/main.yml
+++ b/setup/ansible/roles/common/tasks/main.yml
@@ -10,7 +10,20 @@
       - python-is-python3
       - python3-pip
       - ssh
-      - v4l2loopback-dkms
+  become: true
+
+- name: Clone v4l2loopback repository
+  git:
+    repo: 'https://github.com/umlaeute/v4l2loopback.git'
+    dest: ~/v4l2loopback
+
+- name: Compile and install v4l2loopback
+  make:
+    chdir: ~/v4l2loopback
+    target: install
+
+- name: Run depmod
+  command: depmod -a
   become: true
 
 - name: Add user to dialout


### PR DESCRIPTION
ubuntu22.04でkernel 6.8.0が配信されましたが、こちらにaptでv4l2loopback-dkmsが入れられません(kernel6.8.0に対応したバージョンが配信されていない)。
なので、ローカルでビルドしてinstallする仕様に変更します。