### PR TITLE
Fix depthai version for 2

### DIFF
--- a/sdk/akari_client/setup.py
+++ b/sdk/akari_client/setup.py
@@ -39,7 +39,7 @@ setup(
         ],
         "depthai": [
             "matplotlib",
-            "depthai",
+            "depthai==2.30.0",
             "opencv-python",
             "blobconverter",
         ],


### PR DESCRIPTION
depthaiのバージョン3がリリースされてしまいました。
これにより既存のAKARIのアプリが全て最新のdepthaiでは動かなくなります。
とりあえずdepthaiのバージョンを2の最新に固定します。