### PR TITLE
Fix setup

### DIFF
--- a/setup/ansible/roles/dynamixel/tasks/main.yml
+++ b/setup/ansible/roles/dynamixel/tasks/main.yml
@@ -10,6 +10,6 @@
 
 - name: Add dynamixel authentification rules
   file:
-    path: /dev/ttyUSB_dynamixel
+    path: /dev/ttyUSB0
     owner: '{{ ansible_env.USER }}'
   become: true


### PR DESCRIPTION
This pull request makes a small but important change to the Ansible role for Dynamixel device setup. The device path in the authentication rules has been corrected to `/dev/ttyUSB0`, which is the standard device name for USB serial connections.

- Changed the device path in the Dynamixel authentication rules from `/dev/ttyUSB_dynamixel` to `/dev/ttyUSB0` in `main.yml` to ensure proper permissions are set for the correct device.