### PR TITLE
Fix dynamixel udev reload order

### DIFF
--- a/setup/ansible/roles/dynamixel/tasks/main.yml
+++ b/setup/ansible/roles/dynamixel/tasks/main.yml
@@ -6,10 +6,15 @@
     mode: "644"
     line: 'KERNEL=="ttyUSB*", DRIVERS=="ftdi_sio", MODE="0666", ATTR{device/latency_timer}="1", SYMLINK+="ttyUSB_dynamixel"'
   become: yes
-  notify: Reload udev rules
+  register: dynamixel_udev
+
+- name: Reload udev rules
+  shell: udevadm control --reload-rules && udevadm trigger
+  become: true
+  when: dynamixel_udev.changed
 
 - name: Add dynamixel authentification rules
   file:
-    path: /dev/ttyUSB0
+    path: /dev/ttyUSB_dynamixel
     owner: '{{ ansible_env.USER }}'
   become: true


### PR DESCRIPTION
## Summary
- Dynamixel用udevルールのリロードを`notify`ハンドラ（遅延実行）から即時実行タスクに変更
- デバイスパスを`/dev/ttyUSB0`から`/dev/ttyUSB_dynamixel`に修正
- udevルール変更時のみリロード&トリガーを実行（`when: dynamixel_udev.changed`）

## Test plan
- [ ] Dynamixelデバイスを接続した状態でAnsible playbookを実行し、`/dev/ttyUSB_dynamixel`のownerが正しく設定されることを確認
- [ ] 2回目の実行で`Reload udev rules`タスクがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)