### PR TITLE
Exclude submodules from ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ line-length = 88
 target-version = "py312"
 src = ["internal", "sdk", "tools", "samples"]
 exclude = [
+    "setup/akari_m5_software",
     "internal/akira_services/jupyter_lab/jupyter_lab_config.py",
     "sdk/akari_proto/akari_proto/*pb2*",
 ]


### PR DESCRIPTION
## Summary
- ruffのexcludeに`setup/akari_m5_software`（サブモジュール）を追加

## Test plan
- [ ] `uv run ruff check .` でサブモジュール内のファイルがチェック対象外になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)